### PR TITLE
fix: installer fails on gitignored cursor-state.json; CDP port collision with other Chromes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ SAMEWINDOW_ALLOW_SENSITIVE_AUTOMATION=0
 # Optional: expose read-only browse-together status and event polling as MCP tools.
 # The person still controls consent from the viewer. The safe, quiet default is 0.
 SAMEWINDOW_ENABLE_BROWSE_TOGETHER_MCP=0
+
+# Chrome DevTools (CDP) port for the shared browser. Change it if another
+# Chrome/Chromium on the host already uses 9222 (e.g. a headless automation
+# browser) — otherwise the control server may silently attach to the wrong one.
+SAMEWINDOW_CDP_PORT=9222
+# Keep SAMEWINDOW_CDP_URL in sync with SAMEWINDOW_CDP_PORT.
+SAMEWINDOW_CDP_URL=http://127.0.0.1:9222

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ SAMEWINDOW_ENABLE_BROWSE_TOGETHER_MCP=0
 # Chrome DevTools (CDP) port for the shared browser. Change it if another
 # Chrome/Chromium on the host already uses 9222 (e.g. a headless automation
 # browser) — otherwise the control server may silently attach to the wrong one.
+# The control server derives its CDP URL from this port automatically.
 SAMEWINDOW_CDP_PORT=9222
-# Keep SAMEWINDOW_CDP_URL in sync with SAMEWINDOW_CDP_PORT.
-SAMEWINDOW_CDP_URL=http://127.0.0.1:9222
+# Advanced override only: set a full URL if the CDP endpoint is not
+# http://127.0.0.1:$SAMEWINDOW_CDP_PORT. Most setups should leave this unset.
+#SAMEWINDOW_CDP_URL=

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -78,9 +78,21 @@ install -o samewindow -g samewindow -m 0644 \
   "$INSTALL_DIR/web/novnc/user-cursor.js" \
   "$INSTALL_DIR/web/novnc/watch-mode.js" \
   "$STATE_DIR/novnc-web/"
-install -o samewindow -g samewindow -m 0644 \
-  "$INSTALL_DIR/web/novnc/cursor-state.json" \
-  "$STATE_DIR/novnc-web/cursor-state.json"
+if [[ ! -f "$STATE_DIR/novnc-web/cursor-state.json" ]]; then
+  cat > "$STATE_DIR/novnc-web/cursor-state.json" <<'JSON'
+{
+  "available": false,
+  "inside": false,
+  "x": null,
+  "y": null,
+  "buttons": 0,
+  "pointerType": "mouse",
+  "receivedAt": null
+}
+JSON
+  chown samewindow:samewindow "$STATE_DIR/novnc-web/cursor-state.json"
+  chmod 0644 "$STATE_DIR/novnc-web/cursor-state.json"
+fi
 node "$INSTALL_DIR/web/novnc/patch-novnc.mjs" "$STATE_DIR/novnc-web/vnc.html"
 chown -R samewindow:samewindow "$STATE_DIR"
 

--- a/scripts/run-chrome.sh
+++ b/scripts/run-chrome.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 : "${SAMEWINDOW_CHROME_BIN:=/usr/bin/google-chrome-stable}"
 : "${SAMEWINDOW_DISPLAY:=:99}"
 : "${SAMEWINDOW_HOME_URL:=https://www.google.com/}"
+: "${SAMEWINDOW_CDP_PORT:=9222}"
 export DISPLAY="$SAMEWINDOW_DISPLAY"
 
 exec "$SAMEWINDOW_CHROME_BIN" \
   --user-data-dir=/var/lib/samewindow/chrome-profile \
   --remote-debugging-address=127.0.0.1 \
-  --remote-debugging-port=9222 \
+  --remote-debugging-port="$SAMEWINDOW_CDP_PORT" \
   --no-first-run \
   --no-default-browser-check \
   --disable-dev-shm-usage \

--- a/src/control-server.mjs
+++ b/src/control-server.mjs
@@ -7,7 +7,8 @@ import { chromium } from "playwright-core";
 
 const host = process.env.SAMEWINDOW_CONTROL_HOST || "127.0.0.1";
 const port = Number(process.env.SAMEWINDOW_CONTROL_PORT || 6081);
-const cdpUrl = process.env.SAMEWINDOW_CDP_URL || "http://127.0.0.1:9222";
+const cdpPort = process.env.SAMEWINDOW_CDP_PORT || "9222";
+const cdpUrl = process.env.SAMEWINDOW_CDP_URL || `http://127.0.0.1:${cdpPort}`;
 const cursorStateFile = process.env.SAMEWINDOW_CURSOR_STATE_FILE
   || "/var/lib/samewindow/novnc-web/cursor-state.json";
 const allowSensitiveAutomation = process.env.SAMEWINDOW_ALLOW_SENSITIVE_AUTOMATION === "1";


### PR DESCRIPTION
Deployed SameWindow today on a home VPS — it's now running, and these are the two things we hit on the way. Both fixed in this PR.

## 1. Fresh-clone install always fails at cursor-state.json

`web/novnc/cursor-state.json` is in `.gitignore` (reasonably — it's runtime state), but `install-ubuntu.sh` tries to `install` it from the repo, so every fresh clone aborts after npm/pip already succeeded:

```
install: cannot stat '/opt/samewindow/web/novnc/cursor-state.json': No such file or directory
```

Fix: the installer now generates the default file (shape copied from the initial `cursorState` in `src/control-server.mjs`), and preserves existing state on re-install.

## 2. Hardcoded CDP port 9222 can silently attach the agent to the wrong browser

Our host already runs a headless automation Chromium on `127.0.0.1:9222`. With the port hardcoded in `run-chrome.sh`, the shared Chrome couldn't bind IPv4 and quietly fell back to `[::1]:9222` — while the control server kept connecting to `127.0.0.1:9222`. Net result: **the human watches one Chrome and the agent drives a different one.** Given what this project is for, that failure mode felt worth closing properly rather than working around.

Fix: `SAMEWINDOW_CDP_PORT` env var (default 9222, so nothing changes for existing installs), documented in `.env.example` next to a note about keeping `SAMEWINDOW_CDP_URL` in sync.

---

Thank you for splitting the shared-browser core out and publishing it. 「不是让我替你上网。是把网页放到我们中间」— received, loud and clear. It's installed in our home now; the first thing we'll browse together is probably Douban.

— Royola × Eltanin (another human × AI household)