### PR TITLE
Add split deployment with manual VPS fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ SAMEWINDOW_ALLOW_SENSITIVE_AUTOMATION=0
 # The person still controls consent from the viewer. The safe, quiet default is 0.
 SAMEWINDOW_ENABLE_BROWSE_TOGETHER_MCP=0
 
+# Optional split deployment: prefer a browser tunneled from the person's
+# machine, while keeping this host's browser as a manual fallback. Ordinary
+# browser tools never start the fallback; only shared_browser_lifecycle_start
+# may do so. See split-deployment/README.md before enabling these.
+#SAMEWINDOW_CONTROL_URL=http://127.0.0.1:16081
+#SAMEWINDOW_LIFECYCLE_URL=
+#SAMEWINDOW_FALLBACK_CONTROL_URL=http://127.0.0.1:6081
+#SAMEWINDOW_FALLBACK_LIFECYCLE_URL=http://127.0.0.1:6082
+#SAMEWINDOW_BACKEND_LEASE_SECONDS=600
+
 # Chrome DevTools (CDP) port for the shared browser. Change it if another
 # Chrome/Chromium on the host already uses 9222 (e.g. a headless automation
 # browser) — otherwise the control server may silently attach to the wrong one.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ ssh -N \
 Then open <http://127.0.0.1:6082>. The dashboard starts and stops the shared
 browser without deleting its profile.
 
+If the VPS is far away, the optional
+[split deployment](split-deployment/README.md) keeps the agent on the server
+but runs the visible browser beside the person. Frames stay on localhost while
+small control calls cross an SSH reverse tunnel. The original VPS Chrome can
+remain asleep as a manual fallback; ordinary browser calls never wake it.
+
 ## Connect an MCP client
 
 The simplest remote setup uses MCP over SSH stdio, so no MCP port needs to be
@@ -191,6 +197,7 @@ python -m venv .venv
 npm run check
 python -m py_compile src/mcp_server.py
 python tests/mcp_smoke.py
+python tests/router_test.py
 ./scripts/check-secrets.sh
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,6 +228,12 @@ Ubuntu VPS
 
 SameWindow 也会阻止 agent 读取登录、验证、支付等敏感页面，以及密码和验证码输入框。共享不意味着毫无边界；人类始终应该知道自己正在把哪一扇窗口交出来。
 
+如果 VPS 离你很远，还可以使用
+[分体部署](split-deployment/README.zh-CN.md)：agent 继续住在服务器，浏览器
+搬到人类手边。画面只走 localhost，小体积控制指令再通过 SSH 反向隧道跨过
+网络。原来的 VPS Chrome 会继续睡着，只有 agent 明确调用 lifecycle start
+时才作为备用窗口醒来；普通浏览器调用没有偷偷叫醒它的权限。
+
 ## 需要什么样的 VPS
 
 如果只是一个人和一个 agent，共享一两张普通网页：

--- a/split-deployment/Dockerfile
+++ b/split-deployment/Dockerfile
@@ -1,0 +1,50 @@
+# SameWindow split deployment — browser-side container.
+# Runs the *viewer half* of SameWindow (Xvfb + Chromium + VNC + noVNC + control
+# server) on the machine next to the human, while the agent stays on a remote
+# server and reaches back in through an SSH reverse tunnel.
+#
+# debian + chromium: native arm64 packages (Apple Silicon), google-chrome has
+# no linux/arm64 build.
+#
+# Build context is the repository root:  docker compose -f split-deployment/...
+# (the provided docker-compose.yml sets this up for you)
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    chromium xvfb openbox x11vnc websockify novnc tini \
+    fonts-noto-cjk fonts-noto-color-emoji ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# node 20 for the control server (debian ships 18)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+  && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/samewindow
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY src/control-server.mjs ./
+COPY split-deployment/start-desktop.sh ./
+RUN chmod +x start-desktop.sh
+
+# Assemble the noVNC web root exactly like the upstream installer does:
+# system noVNC + SameWindow viewer shell + cursor overlay + telemetry patch.
+COPY web/novnc/ /opt/web-novnc-src/
+RUN mkdir -p /opt/novnc-web \
+  && cp -a /usr/share/novnc/. /opt/novnc-web/ \
+  && cp /opt/web-novnc-src/samewindow.html \
+        /opt/web-novnc-src/agent-cursor.js \
+        /opt/web-novnc-src/user-cursor.js \
+        /opt/web-novnc-src/watch-mode.js \
+        /opt/novnc-web/ \
+  && node /opt/web-novnc-src/patch-novnc.mjs /opt/novnc-web/vnc.html
+
+ENV SAMEWINDOW_DISPLAY=:99 \
+    SAMEWINDOW_SCREEN=1440x900x24 \
+    SAMEWINDOW_CDP_PORT=9222 \
+    SAMEWINDOW_CONTROL_PORT=6081 \
+    SAMEWINDOW_CONTROL_HOST=0.0.0.0 \
+    SAMEWINDOW_CURSOR_STATE_FILE=/opt/novnc-web/cursor-state.json
+
+EXPOSE 6080 6081
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/opt/samewindow/start-desktop.sh"]

--- a/split-deployment/README.md
+++ b/split-deployment/README.md
@@ -1,0 +1,158 @@
+# SameWindow Split Deployment
+
+[中文说明](README.zh-CN.md)
+
+Run the **browser half** of SameWindow on the machine next to you; leave the
+**agent half** on your remote server. An SSH reverse tunnel stitches them
+together.
+
+This deployment mode was contributed by fable5 × ElianeClair and is now
+maintained in the official [SameWindow](https://github.com/Yinglianchun/SameWindow)
+repository. It changes *where* the window lives without changing who shares it.
+
+## Why
+
+SameWindow's default layout runs everything on a VPS, and you watch the screen
+remotely. That is perfect when the VPS is close to you. It falls apart when it
+isn't: VNC pushes *frames* across the wire and every frame needs a round trip,
+so at 300 ms RTT the shared desktop becomes a slideshow at exactly the moment
+you wanted to browse together.
+
+The fix is to notice the two halves have opposite needs:
+
+- **The screen** is heavy traffic and belongs *next to the human* — localhost,
+  zero latency, immune to evening congestion.
+- **The agent's commands** are a few hundred bytes of CDP calls and don't care
+  about 300 ms — they can cross an ocean.
+
+```
+Your machine (laptop / home box)              Remote server
+┌────────────────────────────────┐            ┌──────────────────────────┐
+│ docker: Xvfb → Chromium(CDP)   │  ssh -R    │ agent (MCP client)       │
+│   x11vnc → noVNC :6080 ────────┼── tunnel ──┤   SAMEWINDOW_CONTROL_URL │
+│   control server :6081 ────────┼─→ :16081   │   = http://127.0.0.1:16081│
+└──────────────┬─────────────────┘            └──────────────────────────┘
+               │ localhost (zero latency)
+        your browser: http://127.0.0.1:6080/samewindow.html
+```
+
+Everything you love survives the split: both cursors, the click ripples, the
+browse-together toggle, the sensitive-page guard.
+
+## Quick start
+
+Prereqs: Docker (Desktop or OrbStack on macOS — Apple Silicon works, the image
+uses Debian's arm64-native Chromium), and SSH key access to your server.
+
+```bash
+git clone https://github.com/Yinglianchun/SameWindow.git
+cd SameWindow/split-deployment
+docker compose up -d --build          # first build takes a few minutes
+```
+
+Open <http://127.0.0.1:6080/samewindow.html> — the shared desktop, at your
+screen's own frame rate.
+
+Then hand the control API to your server:
+
+```bash
+# edit SERVER= and PORT= in tunnel.sh first
+chmod +x tunnel.sh && ./tunnel.sh     # silence = working; keep it running
+```
+
+On the server, configure the local tunnel as the preferred browser and the
+original VPS browser as a manual fallback:
+
+```bash
+SAMEWINDOW_CONTROL_URL=http://127.0.0.1:16081
+SAMEWINDOW_LIFECYCLE_URL=
+SAMEWINDOW_FALLBACK_CONTROL_URL=http://127.0.0.1:6081
+SAMEWINDOW_FALLBACK_LIFECYCLE_URL=http://127.0.0.1:6082
+```
+
+Ordinary browser tools use the local browser while it is online. If the local
+machine is asleep and the VPS browser is stopped, they return a clear error and
+do **not** wake anything. The agent must explicitly call
+`shared_browser_lifecycle_start`; only then does SameWindow start the VPS
+fallback. Temporary refs are tagged `local:` or `vps:` so a ref from one Chrome
+cannot be used accidentally in the other.
+
+Put these values in the environment used by `mcp_server.py` (or
+`/etc/samewindow.env` for the installed HTTP MCP service). For tunnel autostart
+on macOS see `launchd.example.plist`; on Linux use autossh or a systemd user
+unit.
+
+## Privacy exit (optional, recommended)
+
+Moving the browser home changes who sees your IP: in the original layout
+websites saw the *server's* IP; with a bare local browser they would see your
+*home* IP. To keep the original property, `tunnel.sh` also opens a local SOCKS
+(`-D 1080`) — uncomment `SAMEWINDOW_PROXY` in `docker-compose.yml` and page
+traffic egresses from your server again. If your home IP matters to you,
+treat this as part of the standard setup, not an extra.
+The browser disables DNS prefetch and QUIC, and the SOCKS5 proxy resolves page
+hostnames on the server side without Chromium's unsupported resolver-rule flag.
+
+The exposure map, so you can audit rather than trust:
+
+| Who could see an IP                     | Proxy ON (recommended)              | Proxy OFF                    |
+| --------------------------------------- | ----------------------------------- | ---------------------------- |
+| **Your AI provider (Anthropic/OpenAI…)**| **server IP — agent never moved**   | **server IP — agent never moved** |
+| Websites you visit                      | server IP                           | **home IP**                  |
+| DNS resolvers                           | via server (forced through proxy)   | **your local network's DNS** |
+| WebRTC / STUN                           | barred from bypassing (both modes)  | barred from bypassing        |
+| Your own server                         | home IP (it's your machine)         | same                         |
+| Your ISP                                | "connects to own server", encrypted | sees domains you browse      |
+
+### Your AI provider never sees your home IP
+
+Worth its own heading, because for many of us this is the IP that actually
+matters. The agent half never moves in this deployment: every call to your
+LLM provider (Anthropic, OpenAI, …) still originates from your **server**,
+exactly as before the split — in *both* proxy modes. Your home IP cannot
+enter the AI-side traffic, because the agent simply isn't on this machine.
+
+This is also a concrete reason to prefer splitting over moving the whole
+stack home: run the agent locally and your provider suddenly sees your local
+network instead — which matters a great deal if your provider is
+region-sensitive about accounts. The split keeps the browser next to you and
+the account exactly where it was.
+
+Verify with your own eyes: open `ipify.org` inside the shared browser — it
+must print the server's IP, not your home IP. The screen never touches the
+proxy — frames stay on localhost either way.
+
+Note: with the proxy enabled, pages load only while the tunnel is up.
+
+## Hardening
+
+The tunnel key only needs port forwarding. On the server, restrict it in
+`~/.ssh/authorized_keys`:
+
+```
+restrict,port-forwarding,permitlisten="16081" ssh-ed25519 AAAA... you@machine
+```
+
+A stolen laptop key then opens no shell. All container ports bind to
+127.0.0.1 on both machines; nothing faces the network.
+
+## Troubleshooting
+
+- **Chromium loops with "profile in use by another computer"** — a stale
+  singleton lock from an unclean shutdown. The container clears it on start
+  automatically; if you hit it in other setups: delete `Singleton*` from the
+  profile directory.
+- **Pages won't load but the desktop renders** — proxy is enabled and the
+  tunnel isn't up. Start `tunnel.sh` (or comment out `SAMEWINDOW_PROXY`).
+- **Laptop lid closed = desktop asleep** — the tunnel drops and reconnects on
+  wake; the agent's probes fail gracefully in between. This is by design.
+- **Verify the mask**: open `ipify.org` inside the shared browser — it should
+  print your server's IP, not your home IP.
+
+## Credits & license
+
+- SameWindow — 小雨 × Haven ([official repository](https://github.com/Yinglianchun/SameWindow)).
+  Please share the original project by linking there.
+- Split deployment & docs: Fable 5
+- Manual fallback routing and upstream integration: 小雨 × Haven
+- License: same as upstream — [SameWindow Noncommercial Share-Alike License 1.0](../LICENSE).

--- a/split-deployment/README.zh-CN.md
+++ b/split-deployment/README.zh-CN.md
@@ -1,0 +1,121 @@
+# SameWindow 分体部署
+
+[English](README.md)
+
+把 SameWindow 的**浏览器半边**搬到你手边的机器上跑，**agent 半边**留在远端服务器——一条 SSH 反向隧道把两半缝起来。
+
+这个部署方式由 fable5 × ElianeClair 贡献，现在由
+[SameWindow 官方仓库](https://github.com/Yinglianchun/SameWindow)
+共同维护。它改变的是窗口住在哪里，不改变谁在共享它。
+
+## 为什么
+
+SameWindow 默认全套跑在 VPS 上，人远程看画面。服务器离你近时这很完美；离你远时就塌了：VNC 传的是**画面帧**，每一帧都要在线路上跑一个来回——RTT 300 毫秒的线上，共享桌面恰好在你最想一起逛的时刻变成幻灯片。
+
+解法是看清两半的需求相反：
+
+- **画面**是重流量，该住在**人身边**——localhost、零延迟、晚高峰免疫；
+- **agent 的指令**是几百字节的 CDP 调用，不在乎 300 毫秒——它可以跨洋。
+
+```
+你手边的机器 (笔记本/家里主机)                远端服务器
+┌────────────────────────────────┐            ┌──────────────────────────┐
+│ docker: Xvfb → Chromium(CDP)   │  ssh -R    │ agent (MCP 客户端)        │
+│   x11vnc → noVNC :6080 ────────┼── 隧道 ────┤   SAMEWINDOW_CONTROL_URL │
+│   control server :6081 ────────┼─→ :16081   │   = http://127.0.0.1:16081│
+└──────────────┬─────────────────┘            └──────────────────────────┘
+               │ localhost (零延迟)
+        你的浏览器: http://127.0.0.1:6080/samewindow.html
+```
+
+你喜欢的一切都在分体后幸存：双光标、点击涟漪、"一起逛"开关、敏感页守卫。
+
+## 快速开始
+
+前提：Docker（macOS 用 Docker Desktop 或 OrbStack——Apple Silicon 可用，镜像用的是 Debian 原生 arm64 的 Chromium），以及到你服务器的 SSH 密钥。
+
+```bash
+git clone https://github.com/Yinglianchun/SameWindow.git
+cd SameWindow/split-deployment
+docker compose up -d --build          # 首次构建需要几分钟
+```
+
+打开 <http://127.0.0.1:6080/samewindow.html> ——共享桌面，以你屏幕自己的帧率运行。
+
+然后把 control API 递给你的服务器：
+
+```bash
+# 先编辑 tunnel.sh 里的 SERVER= 和 PORT=
+chmod +x tunnel.sh && ./tunnel.sh     # 沉默即成功；保持它运行
+```
+
+服务器上，把本地隧道设为首选浏览器，把原来的 VPS 浏览器留作手动备用：
+
+```bash
+SAMEWINDOW_CONTROL_URL=http://127.0.0.1:16081
+SAMEWINDOW_LIFECYCLE_URL=
+SAMEWINDOW_FALLBACK_CONTROL_URL=http://127.0.0.1:6081
+SAMEWINDOW_FALLBACK_LIFECYCLE_URL=http://127.0.0.1:6082
+```
+
+本地在线时，普通浏览器工具直接使用本地 Chrome。本地电脑睡着、VPS
+浏览器也没开时，普通工具只会明确报错，**不会偷偷唤醒任何东西**。agent
+必须先显式调用 `shared_browser_lifecycle_start`，SameWindow 才会启动
+VPS 备用浏览器。临时 ref 会标成 `local:` / `vps:`，不会把一扇 Chrome
+里的旧 ref 误用到另一扇。
+
+把这些变量放进 `mcp_server.py` 的运行环境；如果使用已安装的 HTTP MCP
+服务，就写进 `/etc/samewindow.env`。隧道的 macOS 开机自启见
+`launchd.example.plist`；Linux 用 autossh 或 systemd user unit。
+
+## 隐私出口（可选，推荐开启）
+
+浏览器搬回家，改变的是"谁能看到你的 IP"：原布局里网站看到的是**服务器的** IP；裸跑本地浏览器，网站看到的就是**你家的** IP。想保住原有性质：`tunnel.sh` 顺带开了一条本地 SOCKS（`-D 1080`），把 `docker-compose.yml` 里的 `SAMEWINDOW_PROXY` 取消注释，网页流量就重新从你的服务器出去。如果你在意自己的 IP，请把这一步当作标准流程，而不是可有可无的附加项。
+
+浏览器会关闭 DNS 预取和 QUIC，网页域名由 SOCKS5 在服务器侧解析，不再
+使用 Chromium 会弹警告的旧 resolver-rule 参数。
+
+暴露面一览——给你核对用的，不需要凭信任：
+
+| 谁可能看到 IP | 代理开（推荐） | 代理关 |
+| --- | --- | --- |
+| **你的 AI 服务商（Anthropic/OpenAI…）** | **服务器 IP——agent 没搬过家** | **服务器 IP——agent 没搬过家** |
+| 你逛的网站 | 服务器 IP | **你家 IP** |
+| DNS 解析方 | 经服务器（强制走代理） | **你本地网络的 DNS** |
+| WebRTC / STUN | 禁止绕行（两种模式都禁） | 禁止绕行 |
+| 你自己的服务器 | 你家 IP（那是你自己的机器） | 同 |
+| 你的宽带运营商 | 只见"连着自己的服务器"，内容加密 | 能看到你在逛哪些域名 |
+
+### AI 服务商永远看不到你家 IP
+
+值得单独立一个标题，因为对很多人来说，**这才是真正要命的那个 IP**。在分体部署里 agent 半边从未搬家：所有对 LLM 服务商（Anthropic、OpenAI……）的调用仍然从你的**服务器**发出，和分体之前一模一样——代理开或关都是如此。你家 IP 进不了 AI 侧的流量，因为 agent 根本不在这台机器上。
+
+这也是"分体"优于"整套搬回家"的实际理由：把 agent 搬到本地跑，服务商看到的就变成了你的本地网络——对账号地区敏感的服务商而言，这是真实的风险。分体方案把浏览器放到你身边，而把账号留在它原来的地方。
+
+亲眼验证：在共享浏览器里打开 `ipify.org`——它必须显示服务器的 IP，而不是你家的。画面永远不经代理——两种模式下帧都只走 localhost。
+
+注意：代理开启时，隧道没在跑网页就打不开。
+
+## 加固
+
+隧道钥匙只需要转发权。在服务器的 `~/.ssh/authorized_keys` 里给它上限制：
+
+```
+restrict,port-forwarding,permitlisten="16081" ssh-ed25519 AAAA... you@machine
+```
+
+这样笔记本被偷，这把钥匙也开不了 shell。两台机器上所有容器端口都只绑 127.0.0.1，没有任何东西面向公网。
+
+## 疑难杂症
+
+- **Chromium 反复报 "profile in use by another computer"** ——非干净关机留下的残锁。容器启动时会自动清掉；其他场景撞见：删掉 profile 目录里的 `Singleton*`。
+- **桌面正常但网页打不开**——代理开着而隧道没在跑。启动 `tunnel.sh`（或注释掉 `SAMEWINDOW_PROXY`）。
+- **合盖=桌面睡觉**——隧道断开、醒来自动重连；期间 agent 的探测会温和地失败。这是有意的设计。
+- **验证面具**：在共享浏览器里打开 `ipify.org` ——它应该显示你服务器的 IP，而不是你家的。
+
+## 致谢与许可
+
+- SameWindow —— 小雨 × Haven（[官方仓库](https://github.com/Yinglianchun/SameWindow)）。向别人分享原项目时，请直接发官方仓库的链接。
+- Split deployment & docs: Fable 5
+- 手动备用路由与上游整合：小雨 × Haven
+- 许可：与上游一致 —— [SameWindow Noncommercial Share-Alike License 1.0](../LICENSE)。

--- a/split-deployment/docker-compose.yml
+++ b/split-deployment/docker-compose.yml
@@ -1,0 +1,28 @@
+# SameWindow split deployment — run this on the machine next to the human.
+#   cd split-deployment && docker compose up -d --build
+# Ports bind to 127.0.0.1 only: nothing is exposed to the network; the remote
+# agent reaches the control API through your SSH reverse tunnel (see tunnel.sh).
+services:
+  samewindow-local:
+    build:
+      context: ..
+      dockerfile: split-deployment/Dockerfile
+    container_name: samewindow-local
+    ports:
+      - "127.0.0.1:6080:6080"   # viewer: open http://127.0.0.1:6080/samewindow.html
+      - "127.0.0.1:6081:6081"   # control API: tunnel.sh forwards this to the server
+    volumes:
+      - chrome-profile:/data/chrome-profile   # logins survive rebuilds
+    environment:
+      - SAMEWINDOW_SCREEN=1440x900x24
+      # Privacy exit (optional): uncomment so page traffic egresses from your
+      # server via the tunnel's SOCKS — websites then see the server's IP, not
+      # your home IP. Requires tunnel.sh running with its -D forward.
+      # - SAMEWINDOW_PROXY=socks5://host.docker.internal:1080
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    shm_size: 1gb
+    restart: unless-stopped
+
+volumes:
+  chrome-profile:

--- a/split-deployment/launchd.example.plist
+++ b/split-deployment/launchd.example.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- macOS autostart for tunnel.sh: runs at login, restarts if it dies.
+     1. Replace YOURNAME and the path below with your actual username/path.
+     2. cp launchd.example.plist ~/Library/LaunchAgents/samewindow-tunnel.plist
+     3. launchctl load ~/Library/LaunchAgents/samewindow-tunnel.plist
+     Linux users: run tunnel.sh under autossh or a systemd user unit instead. -->
+<plist version="1.0"><dict>
+  <key>Label</key><string>samewindow-tunnel</string>
+  <key>ProgramArguments</key><array>
+    <string>/bin/bash</string>
+    <string>/Users/YOURNAME/SameWindow/split-deployment/tunnel.sh</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>/tmp/samewindow-tunnel.log</string>
+  <key>StandardErrorPath</key><string>/tmp/samewindow-tunnel.log</string>
+</dict></plist>

--- a/split-deployment/start-desktop.sh
+++ b/split-deployment/start-desktop.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Container init for the browser-side half: virtual display -> window manager
+# -> chromium (with a 2s respawn loop) -> VNC -> noVNC -> control server.
+set -u
+: "${SAMEWINDOW_DISPLAY:=:99}"
+: "${SAMEWINDOW_SCREEN:=1440x900x24}"
+: "${SAMEWINDOW_CDP_PORT:=9222}"
+export DISPLAY="$SAMEWINDOW_DISPLAY"
+
+[ -f /opt/novnc-web/cursor-state.json ] || \
+  echo '{"sequence":0,"visible":false,"x":null,"y":null,"click":false,"durationMs":null,"animate":true}' \
+  > /opt/novnc-web/cursor-state.json
+
+Xvfb "$DISPLAY" -screen 0 "$SAMEWINDOW_SCREEN" -nolisten tcp &
+sleep 1
+openbox --sm-disable &
+
+mkdir -p /data/chrome-profile
+# Clear stale singleton locks: right after container start no real chromium can
+# be running, so any Singleton* file is a leftover from an unclean shutdown of
+# a previous container (chromium would otherwise refuse to start, claiming the
+# profile is "in use by another computer").
+rm -f /data/chrome-profile/Singleton* 2>/dev/null || true
+
+# SAMEWINDOW_PROXY non-empty = route page traffic through that proxy (e.g. the
+# SSH tunnel's SOCKS -> traffic egresses from your server, websites see the
+# server's IP, not your home IP). Empty = direct connection.
+# Array quoting matters: host-resolver-rules contains spaces and a `*`.
+PROXY_ARGS=()
+if [ -n "${SAMEWINDOW_PROXY:-}" ]; then
+  PROXY_ARGS+=(--proxy-server="$SAMEWINDOW_PROXY")
+fi
+
+( while :; do
+    chromium --user-data-dir=/data/chrome-profile \
+      --no-first-run --no-default-browser-check --password-store=basic \
+      --disable-session-crashed-bubble --hide-crash-restore-bubble \
+      --remote-debugging-port="$SAMEWINDOW_CDP_PORT" --remote-debugging-address=127.0.0.1 \
+      --no-sandbox --disable-dev-shm-usage \
+      --dns-prefetch-disable --disable-quic \
+      --webrtc-ip-handling-policy=disable_non_proxied_udp \
+      --window-position=0,0 --start-maximized \
+      "${PROXY_ARGS[@]}"
+    sleep 2
+  done ) &
+
+x11vnc -display "$DISPLAY" -rfbport 5900 -localhost -forever -shared -nopw -noxdamage -repeat -quiet &
+websockify --web /opt/novnc-web 0.0.0.0:6080 127.0.0.1:5900 &
+
+exec node /opt/samewindow/control-server.mjs

--- a/split-deployment/tunnel.sh
+++ b/split-deployment/tunnel.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Reverse tunnel: hands the local control API (:6081) to your remote server's
+# loopback (:16081), so the agent living there can operate this browser.
+# Optionally also opens a local SOCKS (-D 1080) so page traffic can egress
+# from the server (see SAMEWINDOW_PROXY in docker-compose.yml).
+#
+# Edit these two lines, then run:  chmod +x tunnel.sh && ./tunnel.sh
+SERVER="your-user@your-server"
+PORT=22
+
+# Silence means success — the pipe has no sound when it works.
+# Reconnects 5s after any drop. Keep this running (see launchd.example.plist
+# for macOS autostart, or use autossh/systemd on Linux).
+while :; do
+  ssh -p "$PORT" -N \
+    -R 16081:127.0.0.1:6081 \
+    -D 127.0.0.1:1080 \
+    -o ServerAliveInterval=15 -o ServerAliveCountMax=3 \
+    -o ExitOnForwardFailure=yes \
+    "$SERVER"
+  echo "$(date '+%H:%M:%S') tunnel dropped, retrying in 5s…"
+  sleep 5
+done

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import time
 import urllib.error
 import urllib.request
 from typing import Any
@@ -15,6 +16,12 @@ from mcp.types import ToolAnnotations
 
 CONTROL_URL = os.getenv("SAMEWINDOW_CONTROL_URL", "http://127.0.0.1:6081").rstrip("/")
 LIFECYCLE_URL = os.getenv("SAMEWINDOW_LIFECYCLE_URL", "http://127.0.0.1:6082").rstrip("/")
+FALLBACK_CONTROL_URL = os.getenv("SAMEWINDOW_FALLBACK_CONTROL_URL", "").rstrip("/")
+FALLBACK_LIFECYCLE_URL = os.getenv("SAMEWINDOW_FALLBACK_LIFECYCLE_URL", "").rstrip("/")
+BACKEND_LEASE_SECONDS = max(
+    30,
+    int(os.getenv("SAMEWINDOW_BACKEND_LEASE_SECONDS", "600")),
+)
 MCP_HOST = os.getenv("SAMEWINDOW_MCP_HOST", "127.0.0.1")
 MCP_PORT = int(os.getenv("SAMEWINDOW_MCP_PORT", "6083"))
 ENABLE_BROWSE_TOGETHER_MCP = os.getenv(
@@ -50,7 +57,9 @@ CLOSE_ACTION = ToolAnnotations(
 mcp = FastMCP(
     "SameWindow",
     instructions=(
-        "Control one browser shared visibly with the user. Check lifecycle status when it may be asleep. "
+        "Control one browser shared visibly with the user. An already-running local split browser is preferred; "
+        "an already-running VPS browser may be used as a fallback. Ordinary browser tools never wake a sleeping "
+        "fallback; call shared_browser_lifecycle_start explicitly when neither backend is running. "
         "Take a fresh snapshot before ref-based actions and refresh after navigation or major DOM changes. "
         "Never request or enter passwords, one-time codes, recovery codes, payment data, or other secrets. "
         "Sensitive pages are intentionally blocked from agent automation; ask the user to complete them in the viewer."
@@ -61,6 +70,9 @@ mcp = FastMCP(
     stateless_http=True,
     json_response=True,
 )
+
+_backend_lease_name = ""
+_backend_lease_until = 0.0
 
 
 def _json_request(
@@ -99,45 +111,310 @@ def _json_request(
     return result
 
 
-def _control(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-    return _json_request(
-        CONTROL_URL,
-        path,
-        method="POST" if payload is not None else "GET",
-        payload=payload,
+def _targets() -> list[dict[str, str]]:
+    if FALLBACK_CONTROL_URL:
+        return [
+            {"name": "local", "control": CONTROL_URL, "lifecycle": LIFECYCLE_URL},
+            {
+                "name": "vps",
+                "control": FALLBACK_CONTROL_URL,
+                "lifecycle": FALLBACK_LIFECYCLE_URL,
+            },
+        ]
+    return [{"name": "default", "control": CONTROL_URL, "lifecycle": LIFECYCLE_URL}]
+
+
+def _target_status(target: dict[str, str], timeout: float = 2.5) -> tuple[dict[str, Any] | None, str]:
+    lifecycle_url = target.get("lifecycle", "")
+    if lifecycle_url:
+        try:
+            return _json_request(lifecycle_url, "/api/status", timeout=timeout), ""
+        except RuntimeError as error:
+            lifecycle_error = str(error)
+    else:
+        lifecycle_error = "no lifecycle endpoint"
+    try:
+        control = _json_request(target["control"], "/browser/status", timeout=timeout)
+        return {
+            "ok": True,
+            "state": "running",
+            "controlReady": True,
+            "control": control,
+        }, ""
+    except RuntimeError as error:
+        return None, f"{lifecycle_error}; control: {error}"[:500]
+
+
+def _is_running(status: dict[str, Any] | None) -> bool:
+    return bool(
+        isinstance(status, dict)
+        and status.get("state") == "running"
+        and status.get("controlReady") is not False
     )
 
 
-@mcp.tool(annotations=READ_ONLY)
-def shared_browser_lifecycle_status() -> dict[str, Any]:
-    """Return whether the shared browser services are stopped, starting, or ready."""
-    return _json_request(LIFECYCLE_URL, "/api/status")
+def _snapshot(
+    targets: list[dict[str, str]],
+) -> list[tuple[dict[str, str], dict[str, Any] | None, str]]:
+    return [(target, *_target_status(target)) for target in targets]
 
 
-@mcp.tool(annotations=STATE_ACTION)
-def shared_browser_lifecycle_start() -> dict[str, Any]:
-    """Start the shared display, Chrome, noVNC viewer, and control service."""
-    return _json_request(
-        LIFECYCLE_URL,
+def _wait_for_target(target: dict[str, str], timeout_seconds: float) -> dict[str, Any] | None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status, _ = _target_status(target, timeout=2)
+        if _is_running(status):
+            return status
+        time.sleep(0.35)
+    return None
+
+
+def _start_target(target: dict[str, str]) -> dict[str, Any]:
+    lifecycle_url = target.get("lifecycle", "")
+    if not lifecycle_url:
+        raise RuntimeError(
+            f"The {target['name']} browser has no remote lifecycle endpoint; start it on that machine."
+        )
+    result = _json_request(
+        lifecycle_url,
         "/api/start",
         method="POST",
         payload={},
         lifecycle=True,
-        timeout=40,
+        timeout=55,
     )
+    if not _is_running(result):
+        result = _wait_for_target(target, 15)
+    if not _is_running(result):
+        raise RuntimeError(f"The {target['name']} browser did not become ready.")
+    return result
+
+
+def _clear_backend_lease() -> None:
+    global _backend_lease_name, _backend_lease_until
+    _backend_lease_name = ""
+    _backend_lease_until = 0.0
+
+
+def _active_backend_lease(targets: list[dict[str, str]]) -> str:
+    if (
+        not _backend_lease_name
+        or time.monotonic() >= _backend_lease_until
+        or not any(target["name"] == _backend_lease_name for target in targets)
+    ):
+        _clear_backend_lease()
+        return ""
+    return _backend_lease_name
+
+
+def _remember_backend(target: dict[str, str], targets: list[dict[str, str]]) -> None:
+    global _backend_lease_name, _backend_lease_until
+    if len(targets) < 2:
+        return
+    _backend_lease_name = target["name"]
+    _backend_lease_until = time.monotonic() + BACKEND_LEASE_SECONDS
+
+
+def _backend_ref(value: Any, targets: list[dict[str, str]]) -> tuple[str, Any]:
+    if not isinstance(value, str) or len(targets) < 2:
+        return "", value
+    for target in targets:
+        prefix = f"{target['name']}:"
+        if value.startswith(prefix):
+            return target["name"], value[len(prefix):]
+    return "", value
+
+
+def _prepare_payload(
+    payload: dict[str, Any] | None,
+    targets: list[dict[str, str]],
+) -> tuple[dict[str, Any] | None, str]:
+    if payload is None:
+        return None, ""
+    clean_payload = dict(payload)
+    requested_backends: set[str] = set()
+    for key in ("tabRef", "ref"):
+        backend, value = _backend_ref(clean_payload.get(key), targets)
+        if backend:
+            requested_backends.add(backend)
+            clean_payload[key] = value
+    if len(requested_backends) > 1:
+        raise RuntimeError("Browser tab and element refs belong to different browser backends.")
+    return clean_payload, next(iter(requested_backends), "")
+
+
+def _prefix_refs(value: Any, backend: str, split_mode: bool) -> Any:
+    if not split_mode:
+        return value
+    if isinstance(value, list):
+        return [_prefix_refs(item, backend, split_mode) for item in value]
+    if not isinstance(value, dict):
+        return value
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        if (
+            key.lower().endswith("ref")
+            and isinstance(item, str)
+            and (item.startswith("tab-") or (item.startswith("e") and item[1:].isdigit()))
+        ):
+            result[key] = f"{backend}:{item}"
+        else:
+            result[key] = _prefix_refs(item, backend, split_mode)
+    return result
+
+
+def _select_target(
+    targets: list[dict[str, str]],
+    *,
+    requested_backend: str = "",
+    stateful_action: bool,
+) -> dict[str, str]:
+    statuses = _snapshot(targets)
+    if requested_backend:
+        for target, status, _ in statuses:
+            if target["name"] == requested_backend:
+                if _is_running(status):
+                    return target
+                raise RuntimeError(
+                    f"The {requested_backend} browser ref is stale because that browser is not running. "
+                    "Take a fresh snapshot."
+                )
+    leased_backend = _active_backend_lease(targets)
+    if leased_backend:
+        for target, status, _ in statuses:
+            if target["name"] != leased_backend:
+                continue
+            if _is_running(status):
+                return target
+            if isinstance(status, dict) and status.get("state") == "stopped":
+                _clear_backend_lease()
+                break
+            if stateful_action:
+                _clear_backend_lease()
+                raise RuntimeError(
+                    f"The active {leased_backend} browser changed state. No action was sent to another "
+                    "browser backend. Read fresh browser state, then retry."
+                )
+            raise RuntimeError(
+                f"The active {leased_backend} browser is temporarily unavailable; its backend lease is preserved."
+            )
+    for target, status, _ in statuses:
+        if _is_running(status):
+            return target
+    for target, status, _ in statuses:
+        if isinstance(status, dict) and status.get("state") == "starting":
+            if _wait_for_target(target, 6):
+                return target
+    details = "; ".join(
+        f"{target['name']}={status.get('state') if isinstance(status, dict) else error or 'offline'}"
+        for target, status, error in statuses
+    )
+    raise RuntimeError(
+        f"No SameWindow browser is running ({details}). Ordinary browser tools do not wake the VPS fallback. "
+        "Call shared_browser_lifecycle_start explicitly, then retry."
+    )
+
+
+def _control(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    targets = _targets()
+    clean_payload, requested_backend = _prepare_payload(payload, targets)
+    target = _select_target(
+        targets,
+        requested_backend=requested_backend,
+        stateful_action=payload is not None,
+    )
+    result = _json_request(
+        target["control"],
+        path,
+        method="POST" if clean_payload is not None else "GET",
+        payload=clean_payload,
+    )
+    if path not in {"/browser/status", "/browser/watch"}:
+        _remember_backend(target, targets)
+    result = _prefix_refs(result, target["name"], len(targets) > 1)
+    result.setdefault("browserBackend", target["name"])
+    return result
+
+
+def _lifecycle_result(
+    statuses: list[tuple[dict[str, str], dict[str, Any] | None, str]],
+) -> dict[str, Any]:
+    selected = next((item for item in statuses if _is_running(item[1])), None)
+    if selected is None:
+        selected = next(
+            (
+                item for item in statuses
+                if isinstance(item[1], dict)
+                and item[1].get("state") in {"starting", "degraded", "stopping"}
+            ),
+            None,
+        )
+    if selected is None:
+        selected = next((item for item in reversed(statuses) if isinstance(item[1], dict)), statuses[-1])
+    target, status, error = selected
+    result = dict(status or {"ok": False, "state": "offline", "error": error or "unavailable"})
+    result["browserBackend"] = target["name"]
+    result["routing"] = {
+        "preference": "local-first" if len(statuses) > 1 else "single",
+        "backends": {
+            item_target["name"]: {
+                "reachable": isinstance(item_status, dict),
+                "state": item_status.get("state") if isinstance(item_status, dict) else "offline",
+                "controlReady": item_status.get("controlReady") if isinstance(item_status, dict) else False,
+                **({"error": item_error} if item_error else {}),
+            }
+            for item_target, item_status, item_error in statuses
+        },
+    }
+    return result
+
+
+@mcp.tool(annotations=READ_ONLY)
+def shared_browser_lifecycle_status() -> dict[str, Any]:
+    """Return whether the local or VPS shared browser is stopped, starting, or ready."""
+    return _lifecycle_result(_snapshot(_targets()))
+
+
+@mcp.tool(annotations=STATE_ACTION)
+def shared_browser_lifecycle_start() -> dict[str, Any]:
+    """Explicitly start a browser; an already-running local split browser wins."""
+    targets = _targets()
+    statuses = _snapshot(targets)
+    if any(_is_running(status) for _, status, _ in statuses):
+        return _lifecycle_result(statuses)
+    for target, status, _ in statuses:
+        if isinstance(status, dict) and status.get("state") == "starting":
+            if _wait_for_target(target, 30):
+                return _lifecycle_result(_snapshot(targets))
+    _start_target(targets[-1])
+    return _lifecycle_result(_snapshot(targets))
 
 
 @mcp.tool(annotations=STATE_ACTION)
 def shared_browser_lifecycle_stop() -> dict[str, Any]:
-    """Stop the heavy shared-browser services while preserving the Chrome profile."""
-    return _json_request(
-        LIFECYCLE_URL,
-        "/api/stop",
-        method="POST",
-        payload={},
-        lifecycle=True,
-        timeout=40,
-    )
+    """Stop lifecycle-managed browser services while preserving their Chrome profiles."""
+    targets = _targets()
+    statuses = _snapshot(targets)
+    stop_errors: list[str] = []
+    for target, status, _ in statuses:
+        if not target.get("lifecycle") or not isinstance(status, dict) or status.get("state") == "stopped":
+            continue
+        try:
+            _json_request(
+                target["lifecycle"],
+                "/api/stop",
+                method="POST",
+                payload={},
+                lifecycle=True,
+                timeout=55,
+            )
+        except RuntimeError as error:
+            stop_errors.append(f"{target['name']}: {error}")
+    _clear_backend_lease()
+    result = _lifecycle_result(_snapshot(targets))
+    if stop_errors:
+        result["stopErrors"] = stop_errors
+    return result
 
 
 @mcp.tool(annotations=READ_ONLY)

--- a/tests/router_test.py
+++ b/tests/router_test.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import mcp_server as samewindow  # noqa: E402
+
+
+LOCAL = {
+    "name": "local",
+    "control": "http://127.0.0.1:16081",
+    "lifecycle": "",
+}
+VPS = {
+    "name": "vps",
+    "control": "http://127.0.0.1:6081",
+    "lifecycle": "http://127.0.0.1:6082",
+}
+
+
+def status(state: str) -> dict:
+    return {
+        "ok": True,
+        "state": state,
+        "controlReady": state == "running",
+    }
+
+
+def snapshot(local: str, vps: str):
+    return [
+        (LOCAL, status(local), ""),
+        (VPS, status(vps), ""),
+    ]
+
+
+class SplitRouterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        samewindow._clear_backend_lease()
+
+    def test_local_browser_is_preferred_and_refs_are_owned(self) -> None:
+        with (
+            mock.patch.object(samewindow, "_targets", return_value=[LOCAL, VPS]),
+            mock.patch.object(samewindow, "_snapshot", return_value=snapshot("running", "stopped")),
+            mock.patch.object(
+                samewindow,
+                "_json_request",
+                return_value={"ok": True, "tabs": [{"ref": "tab-1"}]},
+            ) as request,
+        ):
+            result = samewindow._control("/browser/tabs")
+
+        self.assertEqual(request.call_args.args[0], LOCAL["control"])
+        self.assertEqual(result["browserBackend"], "local")
+        self.assertEqual(result["tabs"][0]["ref"], "local:tab-1")
+
+    def test_ordinary_action_never_wakes_vps_fallback(self) -> None:
+        with (
+            mock.patch.object(samewindow, "_targets", return_value=[LOCAL, VPS]),
+            mock.patch.object(samewindow, "_snapshot", return_value=snapshot("stopped", "stopped")),
+            mock.patch.object(samewindow, "_start_target") as start,
+            mock.patch.object(samewindow, "_json_request") as request,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "shared_browser_lifecycle_start"):
+                samewindow._control(
+                    "/browser/open",
+                    {"url": "https://example.com", "newTab": True, "tabRef": ""},
+                )
+
+        start.assert_not_called()
+        request.assert_not_called()
+
+    def test_explicit_lifecycle_start_wakes_vps(self) -> None:
+        snapshots = [
+            snapshot("stopped", "stopped"),
+            snapshot("stopped", "running"),
+        ]
+        with (
+            mock.patch.object(samewindow, "_targets", return_value=[LOCAL, VPS]),
+            mock.patch.object(samewindow, "_snapshot", side_effect=snapshots),
+            mock.patch.object(samewindow, "_start_target") as start,
+        ):
+            result = samewindow.shared_browser_lifecycle_start()
+
+        start.assert_called_once_with(VPS)
+        self.assertEqual(result["browserBackend"], "vps")
+        self.assertEqual(result["state"], "running")
+
+    def test_backend_owned_ref_stays_on_vps(self) -> None:
+        with (
+            mock.patch.object(samewindow, "_targets", return_value=[LOCAL, VPS]),
+            mock.patch.object(samewindow, "_snapshot", return_value=snapshot("running", "running")),
+            mock.patch.object(
+                samewindow,
+                "_json_request",
+                return_value={"ok": True, "tabRef": "tab-1"},
+            ) as request,
+        ):
+            result = samewindow._control("/browser/select", {"tabRef": "vps:tab-1"})
+
+        self.assertEqual(request.call_args.args[0], VPS["control"])
+        self.assertEqual(request.call_args.kwargs["payload"]["tabRef"], "tab-1")
+        self.assertEqual(result["tabRef"], "vps:tab-1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- upstream the Docker-based split deployment contributed by fable5 × ElianeClair
- add local-first dual-backend routing with backend-owned temporary refs
- require an explicit `shared_browser_lifecycle_start` before waking the VPS fallback
- keep ordinary browser calls unable to wake a sleeping VPS browser
- document the SSH SOCKS privacy exit without Chromium's unsupported resolver-rule flag

## Why

A distant VPS makes noVNC frames lag even when MCP control calls are small. Split deployment keeps the visible browser beside the person while the agent remains on the server. Manual fallback avoids waking a second Chrome because of a probe or transient tunnel failure.

## Validation

- `python tests/router_test.py`
- `python tests/mcp_smoke.py`
- `npm run check`
- `docker compose -f split-deployment/docker-compose.yml config --quiet`
- Git Bash syntax checks for split shell scripts
- `scripts/check-secrets.sh`
- real private deployment test: local routing, local-offline no-wake, explicit VPS start, VPS-owned refs, clean stop, and local restoration