### PR TITLE
fix: scope element refs to snapshots

### DIFF
--- a/src/browser-refs.mjs
+++ b/src/browser-refs.mjs
@@ -1,0 +1,62 @@
+export function snapshotElementRef(snapshotId, index) {
+  return `${snapshotId}:e${index + 1}`;
+}
+
+export class ElementRefRegistry {
+  constructor() {
+    this.activeSnapshotId = "";
+    this.entries = new Map();
+  }
+
+  begin(snapshotId) {
+    this.activeSnapshotId = snapshotId;
+    this.entries.clear();
+  }
+
+  commit(snapshotId, entries) {
+    if (snapshotId !== this.activeSnapshotId) {
+      throw new Error("snapshot was superseded; take a fresh snapshot");
+    }
+    for (const entry of entries) {
+      this.entries.set(entry.ref, { ...entry, snapshotId });
+    }
+  }
+
+  resolve(ref, page) {
+    const entry = this.entries.get(ref);
+    if (
+      !entry
+      || entry.page !== page
+      || entry.snapshotId !== this.activeSnapshotId
+    ) {
+      throw new Error(`element ref ${ref} is stale; take a fresh snapshot`);
+    }
+    return entry;
+  }
+
+  pages() {
+    return [...new Set([...this.entries.values()].map((entry) => entry.page))];
+  }
+
+  clear() {
+    this.activeSnapshotId = "";
+    this.entries.clear();
+  }
+}
+
+export function resolvePageReference(
+  tabRef,
+  refToPage,
+  pages,
+  selectedPage,
+  strict = false,
+) {
+  let page = tabRef ? refToPage.get(tabRef) : selectedPage;
+  if (!page || page.isClosed() || !pages.includes(page)) {
+    if (strict && tabRef) {
+      throw new Error(`browser tab ref ${tabRef} is stale; take a fresh snapshot`);
+    }
+    page = pages[0] ?? null;
+  }
+  return page;
+}

--- a/src/control-server.mjs
+++ b/src/control-server.mjs
@@ -4,6 +4,12 @@ import { writeFile } from "node:fs/promises";
 
 import { chromium } from "playwright-core";
 
+import {
+  ElementRefRegistry,
+  resolvePageReference,
+  snapshotElementRef,
+} from "./browser-refs.mjs";
+
 
 const host = process.env.SAMEWINDOW_CONTROL_HOST || "127.0.0.1";
 const port = Number(process.env.SAMEWINDOW_CONTROL_PORT || 6081);
@@ -82,12 +88,11 @@ let browserConnection = null;
 let selectedPage = null;
 let selectedPageObservedAt = 0;
 let nextTabSequence = 1;
-let nextElementSequence = 1;
 let nextSnapshotSequence = 1;
 let cursorSequence = Date.now();
 let pageToRef = new WeakMap();
 let refToPage = new Map();
-let elementRefs = new Map();
+let elementRefs = new ElementRefRegistry();
 
 function sendJson(response, status, value, origin = null) {
   if (origin && allowedOrigins.has(origin)) {
@@ -614,7 +619,7 @@ function resetBrowserState() {
   selectedPageObservedAt = 0;
   pageToRef = new WeakMap();
   refToPage = new Map();
-  elementRefs = new Map();
+  elementRefs = new ElementRefRegistry();
 }
 
 async function getBrowser() {
@@ -640,14 +645,17 @@ function getTabRef(page) {
   return ref;
 }
 
-async function findPage(tabRef = "", bringToFront = false) {
+async function findPage(tabRef = "", bringToFront = false, strict = false) {
   const pages = await getPages();
   for (const page of pages) getTabRef(page);
 
-  let page = tabRef ? refToPage.get(tabRef) : selectedPage;
-  if (!page || page.isClosed() || !pages.includes(page)) {
-    page = pages[0] ?? null;
-  }
+  const page = resolvePageReference(
+    tabRef,
+    refToPage,
+    pages,
+    selectedPage,
+    strict,
+  );
   if (!page) throw new Error("no shared Chrome page is open");
   selectedPage = page;
   if (bringToFront) await page.bringToFront();
@@ -800,7 +808,7 @@ async function closePage(value) {
 }
 
 async function clearElementRefs() {
-  const pages = [...new Set([...elementRefs.values()].map((entry) => entry.page))];
+  const pages = elementRefs.pages();
   elementRefs.clear();
   await Promise.all(pages.map((page) => page.evaluate(() => {
     document.querySelectorAll("[data-samewindow-snapshot-ref]").forEach((element) => {
@@ -817,13 +825,16 @@ async function snapshotPage(value) {
     ? await findPage(tabRef, false)
     : await findObservedPage();
   await assertPageSafe(page, "snapshot");
-  elementRefs.clear();
-  nextElementSequence = 1;
   const snapshotId = `s${nextSnapshotSequence++}`;
+  elementRefs.begin(snapshotId);
+  const snapshotRefs = Array.from(
+    { length: limit },
+    (_, index) => snapshotElementRef(snapshotId, index),
+  );
   const snapshot = await page.evaluate(({
     selector,
     limit: maxElements,
-    snapshotId: activeSnapshotId,
+    refs,
     includePointerExtras,
   }) => {
     document.querySelectorAll("[data-samewindow-snapshot-ref]").forEach((element) => {
@@ -904,8 +915,8 @@ async function snapshotPage(value) {
     }
 
     const elements = candidates.slice(0, maxElements).map((candidate, index) => {
-      const ref = `e${index + 1}`;
-      const marker = `${activeSnapshotId}:${ref}`;
+      const ref = refs[index];
+      const marker = ref;
       candidate.element.setAttribute("data-samewindow-snapshot-ref", marker);
       const { element: _element, ...metadata } = candidate;
       return { ref, marker, ...metadata };
@@ -922,20 +933,22 @@ async function snapshotPage(value) {
   }, {
     selector: interactiveSelector,
     limit,
-    snapshotId,
+    refs: snapshotRefs,
     includePointerExtras: value.includePointerExtras === true,
   });
 
+  const entries = [];
   const elements = snapshot.elements.map(({ marker, ...element }) => {
-    elementRefs.set(element.ref, {
+    entries.push({
+      ref: element.ref,
       page,
       selector: `[data-samewindow-snapshot-ref="${marker}"]`,
-      snapshotId,
     });
-    nextElementSequence += 1;
     return element;
   });
+  elementRefs.commit(snapshotId, entries);
   return {
+    snapshotId,
     tabRef: getTabRef(page),
     title: snapshot.title,
     url: snapshot.url,
@@ -948,13 +961,10 @@ async function snapshotPage(value) {
 }
 
 async function getTarget(value) {
-  const page = await findPage(cleanString(value.tabRef, 50), false);
+  const page = await findPage(cleanString(value.tabRef, 50), false, true);
   const ref = cleanString(value.ref, 30);
   if (!ref) throw new Error("ref from a fresh snapshot is required");
-  const entry = elementRefs.get(ref);
-  if (!entry || entry.page !== page) {
-    throw new Error(`element ref ${ref} is stale; take a fresh snapshot`);
-  }
+  const entry = elementRefs.resolve(ref, page);
   await assertPageSafe(page, "browser action");
   return { page, target: page.locator(entry.selector), ref };
 }

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import time
 import urllib.error
 import urllib.request
@@ -255,7 +256,10 @@ def _prefix_refs(value: Any, backend: str, split_mode: bool) -> Any:
         if (
             key.lower().endswith("ref")
             and isinstance(item, str)
-            and (item.startswith("tab-") or (item.startswith("e") and item[1:].isdigit()))
+            and (
+                item.startswith("tab-")
+                or re.fullmatch(r"(?:s\d+:)?e\d+", item)
+            )
         ):
             result[key] = f"{backend}:{item}"
         else:

--- a/tests/browser-refs.test.mjs
+++ b/tests/browser-refs.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ElementRefRegistry,
+  resolvePageReference,
+  snapshotElementRef,
+} from "../src/browser-refs.mjs";
+
+test("snapshot-scoped element refs cannot rebind to a newer snapshot", () => {
+  const registry = new ElementRefRegistry();
+  const page = {};
+  const firstRef = snapshotElementRef("s1", 0);
+  const secondRef = snapshotElementRef("s2", 0);
+
+  registry.begin("s1");
+  registry.commit("s1", [
+    { ref: firstRef, page, selector: "[data-ref='button-a']" },
+  ]);
+  registry.begin("s2");
+  registry.commit("s2", [
+    { ref: secondRef, page, selector: "[data-ref='button-b']" },
+  ]);
+
+  assert.equal(firstRef, "s1:e1");
+  assert.equal(secondRef, "s2:e1");
+  assert.throws(
+    () => registry.resolve(firstRef, page),
+    /element ref s1:e1 is stale; take a fresh snapshot/,
+  );
+  assert.equal(registry.resolve(secondRef, page).selector, "[data-ref='button-b']");
+});
+
+test("superseded snapshot cannot repopulate the element-ref registry", () => {
+  const registry = new ElementRefRegistry();
+  const page = {};
+
+  registry.begin("s1");
+  registry.begin("s2");
+  registry.commit("s2", [
+    { ref: "s2:e1", page, selector: "[data-ref='button-b']" },
+  ]);
+
+  assert.throws(
+    () => registry.commit("s1", [
+      { ref: "s1:e1", page, selector: "[data-ref='button-a']" },
+    ]),
+    /snapshot was superseded; take a fresh snapshot/,
+  );
+  assert.throws(
+    () => registry.resolve("s1:e1", page),
+    /element ref s1:e1 is stale; take a fresh snapshot/,
+  );
+  assert.equal(registry.resolve("s2:e1", page).selector, "[data-ref='button-b']");
+});
+
+test("strict tab resolution rejects an unknown explicit tab ref", () => {
+  const firstPage = { isClosed: () => false };
+  const pages = [firstPage];
+
+  assert.throws(
+    () => resolvePageReference(
+      "tab-old",
+      new Map(),
+      pages,
+      firstPage,
+      true,
+    ),
+    /browser tab ref tab-old is stale; take a fresh snapshot/,
+  );
+});

--- a/tests/router_test.py
+++ b/tests/router_test.py
@@ -109,6 +109,27 @@ class SplitRouterTest(unittest.TestCase):
         self.assertEqual(request.call_args.kwargs["payload"]["tabRef"], "tab-1")
         self.assertEqual(result["tabRef"], "vps:tab-1")
 
+    def test_snapshot_scoped_element_ref_keeps_backend_ownership(self) -> None:
+        with (
+            mock.patch.object(samewindow, "_targets", return_value=[LOCAL, VPS]),
+            mock.patch.object(samewindow, "_snapshot", return_value=snapshot("running", "stopped")),
+            mock.patch.object(
+                samewindow,
+                "_json_request",
+                return_value={
+                    "ok": True,
+                    "snapshot": {
+                        "tabRef": "tab-1",
+                        "elements": [{"ref": "s42:e1"}],
+                    },
+                },
+            ) as request,
+        ):
+            result = samewindow._control("/browser/snapshot", {"tabRef": "local:tab-1"})
+
+        self.assertEqual(request.call_args.kwargs["payload"]["tabRef"], "tab-1")
+        self.assertEqual(result["snapshot"]["elements"][0]["ref"], "local:s42:e1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- return snapshot-scoped element refs such as `s42:e1` and expose `snapshotId` in snapshot responses
- reject refs from older snapshots and prevent superseded concurrent snapshots from repopulating the ref registry
- reject stale explicit tab refs for element actions instead of silently falling back to another page
- preserve split-backend ownership for snapshot-scoped refs
- add regression coverage for stale-ref rebinding, concurrent snapshots, strict tab resolution, and backend routing

## Why

Element refs were cleared and reassigned from `e1` for every semantic snapshot. An action created from an older snapshot could therefore resolve `e1` against a newer snapshot on the same page and target a different element.

The public click/type schema remains unchanged: callers still pass `tabRef` and `ref`. The ref value is now opaque and snapshot-scoped; consumers that validate the old `e<number>` shape should accept `s<number>:e<number>`.

Fixes #9

## Verification

- `npm run check` (6/6 Node tests)
- `uv run --with mcp==1.27.0 python tests/router_test.py` (5/5 tests)
- `uv run --with mcp==1.27.0 python tests/mcp_smoke.py`
- `python3 -m py_compile src/mcp_server.py`
- `./scripts/check-secrets.sh`
- `git diff --check`